### PR TITLE
chore(template): bump standard-mod to v1.1.3

### DIFF
--- a/config/managed-templates.yml
+++ b/config/managed-templates.yml
@@ -1,7 +1,7 @@
 templates:
 - id: standard-mod
   src: https://github.com/Gluck-House/7dtd-mod-template
-  ref: v1.1.2
+  ref: v1.1.3
   repos:
   - repo: Gluck-House/7dtd-timeloop
     branch: main


### PR DESCRIPTION
Automated promotion of a released template ref.

- Template ID: `standard-mod`
- Template ref: `v1.1.3`
- Managed by: `7dtd-mod-infra`