### PR TITLE
ci: use Gluck House ARC runners

### DIFF
--- a/.github/workflows/promote-template-release.yml
+++ b/.github/workflows/promote-template-release.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: actions-runner-scale-set
     steps:
       - name: Checkout infra repository
         uses: actions/checkout@v6

--- a/.github/workflows/reusable-pr-title.yml
+++ b/.github/workflows/reusable-pr-title.yml
@@ -6,7 +6,7 @@ on:
       runner_label:
         required: false
         type: string
-        default: ubuntu-latest
+        default: actions-runner-scale-set
 
 permissions:
   pull-requests: read

--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -14,7 +14,7 @@ on:
       runner_label:
         required: false
         type: string
-        default: ubuntu-latest
+        default: actions-runner-scale-set
     outputs:
       release_created:
         description: Whether a root release was created

--- a/.github/workflows/update-managed-7dtd-build.yml
+++ b/.github/workflows/update-managed-7dtd-build.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   plan:
-    runs-on: ubuntu-latest
+    runs-on: actions-runner-scale-set
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
       repo_count: ${{ steps.plan.outputs.repo_count }}

--- a/.github/workflows/update-managed-template.yml
+++ b/.github/workflows/update-managed-template.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   plan:
-    runs-on: ubuntu-latest
+    runs-on: actions-runner-scale-set
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
       template_id: ${{ steps.plan.outputs.template_id }}
@@ -63,7 +63,7 @@ jobs:
   update:
     needs: plan
     if: needs.plan.outputs.repo_count != '0'
-    runs-on: ubuntu-latest
+    runs-on: actions-runner-scale-set
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Move the repository workflows from GitHub-hosted runners to the Gluck House `actions-runner-scale-set` ARC runners.

This is a runner-only migration; workflow logic and permissions are unchanged. Reusable 7DTD workflows inherit the ARC default from `7dtd-mod-infra`.

## Validation

- Workflow YAML parsed with trigger/step normalization.
- No `ubuntu-latest`, `macos-latest`, or `windows-latest` references remain in the targeted workflow tree.
- Repository-specific workflow validation will run on this PR.